### PR TITLE
Hotfix : 캘린더 컴포넌트 스타일 오류 수정 및 해당 월이 아닌 경우의 날짜에 대한 스타일 지정

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "chromatic": "npx chromatic --project-token=chpt_331321e81a5d63c"
   },
   "dependencies": {
+    "classnames": "^2.5.1",
     "date-fns": "^3.6.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      classnames:
+        specifier: ^2.5.1
+        version: 2.5.1
       date-fns:
         specifier: ^3.6.0
         version: 3.6.0
@@ -1744,6 +1747,9 @@ packages:
 
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
+  classnames@2.5.1:
+    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
 
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
@@ -5517,6 +5523,8 @@ snapshots:
   citty@0.1.6:
     dependencies:
       consola: 3.2.3
+
+  classnames@2.5.1: {}
 
   cli-cursor@3.1.0:
     dependencies:

--- a/src/pages/MainPage/components/calender/Calender.tsx
+++ b/src/pages/MainPage/components/calender/Calender.tsx
@@ -36,7 +36,7 @@ const renderCalenderItem = (day: Date, currentDate: Date, events: CalenderDataTy
 
 const Calender: React.FC<Props> = ({ currentMonthData, currentDate, calenderData }) => {
   return (
-    <div className="w-[1150px] h-[1067px] border-[3px] border-ButtonDisabled rounded-[10px] flex flex-col items-center gap-[54px]">
+    <div className="w-[1150px] min-h-[1067px] border-[3px] border-ButtonDisabled rounded-[10px] flex flex-col items-center gap-[54px]">
       <div className="flex w-full justify-around mt-[48px]">
         {DAY_LIST.map((day) => (
           <div

--- a/src/pages/MainPage/components/calender/CalenderItem.tsx
+++ b/src/pages/MainPage/components/calender/CalenderItem.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import DefaultLogo from "@assets/images/calenderItem-logo.png";
 import Like from "@pages/MainPage/components/icons/Like";
+import classNames from "classnames";
 
 interface Props {
   day: string;
@@ -11,26 +12,37 @@ interface Props {
 }
 
 const CalenderItem: React.FC<Props> = ({ day, isValidate, hasContent, imageUrl, bookmark }) => {
-  if (isValidate && hasContent) {
+  const renderImage = () => {
+    if (!hasContent) return null;
+
     return (
-      <div className="calender-item  bg-white body-font flex justify-center items-center">
-        {imageUrl ? (
-          <img src={imageUrl} className="calender-item object-cover" alt="그림일기 이미지"></img>
-        ) : (
-          <img src={DefaultLogo} alt="기본 로고 이미지" />
-        )}
+      <>
+        <img
+          src={imageUrl || DefaultLogo}
+          className={`${imageUrl && "calender-item object-cover"} `}
+          alt={imageUrl ? "그림일기 이미지" : "기본 로고 이미지"}
+        />
         {bookmark === 1 && (
           <div className="absolute">
             <Like />
           </div>
         )}
-        <span className="absolute">{day}</span>
-      </div>
+      </>
     );
-  }
+  };
+
+  const containerClassNames = classNames(
+    "calender-item relative flex justify-center items-center",
+    {
+      "text-ButtonDisabledStroke text-regular": !isValidate,
+      "bg-white body-font": isValidate,
+    },
+  );
+
   return (
-    <div className="calender-item  bg-white body-font flex justify-center items-center">
-      <span className="absolute">{isValidate && day}</span>
+    <div className={containerClassNames}>
+      {renderImage()}
+      <span className="absolute">{day}</span>
     </div>
   );
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> cloed #18 

## 📝작업 내용

- Calender 컴포넌트의 기본 h를 지정해두었더니 한달이 6주로 구성된 달의 경우 하단 컴포넌트가 border바깥으로 튀어나오는 오류 발생하여 해결
- 해당 월의 날짜가 아닌 경우 날짜 색상을 ButtonDisabledStorke색상으로 지정하고 화면에 보여줌  
- CalenderItem 컴포넌트 코드 리팩토링

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/7931a68e-0209-41be-b0ab-6bdcbf2d5d63)


## 💬리뷰 요구사항(선택)

 현재 첨부한 사진상에서 회색으로 표시된 날짜에 그림 일기 요소가 뜨는 걸로 나타나는데 이는 더미 데이터로  인한 것이며 실제 api 연동 시 새당 월에 맞는 데이터를 받기때문에 발생하지 않을 오류입니다.
