### PR TITLE
style: 로그인 페이지 퍼블리싱 작업 완료

### DIFF
--- a/src/pages/LoginPage/page/index.tsx
+++ b/src/pages/LoginPage/page/index.tsx
@@ -1,7 +1,31 @@
-import React from 'react';
+import KakaoButton from "@components/buttons/KakaoButton";
+import DefaultDiaryLogo from "@components/default/DefaultDiaryLogo";
+import DefaultHeader from "@components/header/DefaultHeader";
+import React from "react";
 
 const LoginPage: React.FC = () => {
-  return <div>LoginPage</div>;
+
+  const handleLogin = () => {
+    
+  }
+
+  return (
+    <>
+      <DefaultHeader title="띠로리" />
+      <div className="mt-[50px] flex flex-col justify-center items-center gap-[70px]">
+        <DefaultDiaryLogo />
+        <div className="flex flex-col gap-[20px] ">
+          <div className="title-font font-[400] leading-[48.96px]">
+            나만의 일상을 그림으로 그려주는 AI 그림 친구
+          </div>
+          <div className="font-[400] text-[28px] leading-[38.08px] text-Primary">
+            띠로리와 함께, 나의 하루를 그림으로 기록해요!
+          </div>
+        </div>
+        <KakaoButton onClick={handleLogin} />
+      </div>
+    </>
+  );
 };
 
 export default LoginPage;

--- a/src/pages/LoginPage/page/index.tsx
+++ b/src/pages/LoginPage/page/index.tsx
@@ -15,10 +15,10 @@ const LoginPage: React.FC = () => {
       <div className="flex-grow flex flex-col justify-center items-center gap-[80px]">
         <DefaultDiaryLogo />
         <div className="flex flex-col gap-[20px] ">
-          <div className="title-font font-[400] leading-[48.96px]">
+          <div className="title-font leading-[48.96px]">
             나만의 일상을 그림으로 그려주는 AI 그림 친구
           </div>
-          <div className="font-[400] text-[28px] leading-[38.08px] text-Primary">
+          <div className="text-[28px] leading-[38.08px] text-Primary">
             띠로리와 함께, 나의 하루를 그림으로 기록해요!
           </div>
         </div>

--- a/src/pages/LoginPage/page/index.tsx
+++ b/src/pages/LoginPage/page/index.tsx
@@ -10,9 +10,9 @@ const LoginPage: React.FC = () => {
   }
 
   return (
-    <>
+    <div className="flex flex-col h-screen">
       <DefaultHeader title="띠로리" />
-      <div className="mt-[50px] flex flex-col justify-center items-center gap-[70px]">
+      <div className="flex-grow flex flex-col justify-center items-center gap-[80px]">
         <DefaultDiaryLogo />
         <div className="flex flex-col gap-[20px] ">
           <div className="title-font font-[400] leading-[48.96px]">
@@ -24,7 +24,7 @@ const LoginPage: React.FC = () => {
         </div>
         <KakaoButton onClick={handleLogin} />
       </div>
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #29 

## 📝작업 내용
> - 로그인 페이지 퍼블리싱 작업 완료
> - 로그인 페이지에서 헤더 이외의 요소에 h-screen을 주고 하위 요소에 flex-grow를 줌으로써 헤더를 제외한 컴포넌트들이 나머지 화면 전체높이를 차지할 수 있도록 수정
### 리뷰 후 수정 내용
> - font-[400]은 기본 폰트 weight이므로 스타일 지정 코드 삭제  

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/375373fc-ce64-4962-8bbc-a3f02342e938)


## 💬리뷰 요구사항(선택)