### PR TITLE
Style: 메인 페이지(캘린더형, 목록형) 퍼블리싱 작업 완료

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.1",
-    "swiper": "^11.1.12"
+    "swiper": "^11.1.12",
+    "zustand": "^4.5.5"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "1.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       swiper:
         specifier: ^11.1.12
         version: 11.1.12
+      zustand:
+        specifier: ^4.5.5
+        version: 4.5.5(@types/react@18.3.5)(react@18.3.1)
     devDependencies:
       '@chromatic-com/storybook':
         specifier: 1.6.1
@@ -3473,6 +3476,11 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-sync-external-store@1.2.2:
+    resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -3588,6 +3596,21 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zustand@4.5.5:
+    resolution: {integrity: sha512-+0PALYNJNgK6hldkgDq2vLrw5f6g/jCInz52n9RTpropGgeAf/ioFUCdtsjCqu4gNhW9D01rUQBROoRjdzyn2Q==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
 snapshots:
 
@@ -7293,6 +7316,10 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  use-sync-external-store@1.2.2(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   util-deprecate@1.0.2: {}
 
   util@0.12.5:
@@ -7371,3 +7398,10 @@ snapshots:
   yaml@2.5.0: {}
 
   yocto-queue@0.1.0: {}
+
+  zustand@4.5.5(@types/react@18.3.5)(react@18.3.1):
+    dependencies:
+      use-sync-external-store: 1.2.2(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.5
+      react: 18.3.1

--- a/src/components/buttons/Button.stories.tsx
+++ b/src/components/buttons/Button.stories.tsx
@@ -28,10 +28,30 @@ function Button() {
 
       <div className="flex flex-col gap-8">
         <h1 className="text-16 bg-white w-fit p-4">ModalButton</h1>
-        <ModalButton title="넹" />
-        <ModalButton title="이미지로" />
-        <ModalButton title="아니용" />
-        <ModalButton title="링크로" />
+        <ModalButton
+          title="넹"
+          onClick={() => {
+            return;
+          }}
+        />
+        <ModalButton
+          title="이미지로"
+          onClick={() => {
+            return;
+          }}
+        />
+        <ModalButton
+          title="아니용"
+          onClick={() => {
+            return;
+          }}
+        />
+        <ModalButton
+          title="링크로"
+          onClick={() => {
+            return;
+          }}
+        />
       </div>
 
       <div className="flex flex-col gap-8">

--- a/src/components/buttons/ToggleButton.tsx
+++ b/src/components/buttons/ToggleButton.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import { useToggleStore } from "@store/useToggleStore";
+import React, { useEffect, useState } from "react";
 
 interface ToggleButtonProps {
   leftTitle: "캘린더형" | "전체보기";
@@ -7,21 +8,34 @@ interface ToggleButtonProps {
 
 const ToggleButton: React.FC<ToggleButtonProps> = ({ leftTitle, rightTitle }) => {
   const [activeButtonTitle, setActiveButtonTitle] = useState<string>(leftTitle);
+  const { setIsTotalView, setIsCalenderView, isTotalView, isCalenderView } = useToggleStore();
   const [isLeftActive, setIsLeftActive] = useState<boolean>(true);
+
+  useEffect(() => {
+    if (leftTitle === "캘린더형") {
+      setIsLeftActive(isCalenderView);
+    } else {
+      setIsLeftActive(isTotalView);
+    }
+  }, [leftTitle]);
 
   const handleToggle = () => {
     if (activeButtonTitle === leftTitle) {
       if (leftTitle === "캘린더형") {
         setActiveButtonTitle("목록형");
+        setIsCalenderView(false);
       } else {
         setActiveButtonTitle("날짜별");
+        setIsTotalView(false);
       }
       setIsLeftActive(false);
     } else {
       if (rightTitle === "날짜별") {
         setActiveButtonTitle("전체보기");
+        setIsTotalView(true);
       } else {
         setActiveButtonTitle("캘린더형");
+        setIsCalenderView(true);
       }
       setIsLeftActive(true);
     }
@@ -31,7 +45,9 @@ const ToggleButton: React.FC<ToggleButtonProps> = ({ leftTitle, rightTitle }) =>
     <div className="flex rounded-[10px] border border-ButtonDisabledStroke w-[270px] h-[60px] text-regular leading-[38.08px]">
       <button
         onClick={() => {
-          !isLeftActive && handleToggle();
+          if (!isLeftActive) {
+            handleToggle();
+          }
         }}
         className={`w-[134px] h-[58px] rounded-[10px] ${
           isLeftActive ? "bg-PrimaryStroke text-white" : "bg-white text-Charcoal"
@@ -41,7 +57,9 @@ const ToggleButton: React.FC<ToggleButtonProps> = ({ leftTitle, rightTitle }) =>
       </button>
       <button
         onClick={() => {
-          isLeftActive && handleToggle();
+          if (isLeftActive) {
+            handleToggle();
+          }
         }}
         className={`w-[136px] h-[58px] rounded-[10px] ${
           isLeftActive ? "bg-white text-Charcoal" : "bg-PrimaryStroke text-white"

--- a/src/components/diary/DiaryItem.tsx
+++ b/src/components/diary/DiaryItem.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 const DiaryItem: React.FC<Props> = ({ imageUrl, title, date, likeStatus }) => {
   return (
-    <div className="w-[950px] h-[275px] bg-white flex items-center justify-between border-b-[3px] border-buttonDisabled">
+    <div className="min-w-[1012.53px] h-[275px] bg-white flex items-center justify-between border-b-[3px] border-buttonDisabled">
       <div className="flex items-center gap-[46px]">
         {imageUrl ? (
           <img

--- a/src/components/diary/DiaryList.tsx
+++ b/src/components/diary/DiaryList.tsx
@@ -5,7 +5,7 @@ const DUMMY_IMG = "https://avatars.githubusercontent.com/u/77326820?v=4";
 
 const DiaryList: React.FC = () => {
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col w-full">
       <DiaryItem
         imageUrl={DUMMY_IMG}
         title="신나는 산책을 했따."

--- a/src/components/header/DefaultHeader.tsx
+++ b/src/components/header/DefaultHeader.tsx
@@ -7,7 +7,7 @@ interface DefaultHeaderProps {
 const DefaultHeader: React.FC<DefaultHeaderProps> = ({ title }) => {
   return (
       <div
-        className={`sticky top-0 flex w-full p-0 h-[82px] justify-center items-center ${
+        className={`z-[50] sticky top-0 flex w-full p-0 h-[82px] justify-center items-center ${
           title === "일기 쓰기" ? "bg-Highlight" : "bg-Primary"
         }`}
       >

--- a/src/components/header/DefaultHeader.tsx
+++ b/src/components/header/DefaultHeader.tsx
@@ -6,13 +6,13 @@ interface DefaultHeaderProps {
 
 const DefaultHeader: React.FC<DefaultHeaderProps> = ({ title }) => {
   return (
-      <div
-        className={`z-[50] sticky top-0 flex w-full p-0 h-[82px] justify-center items-center ${
-          title === "일기 쓰기" ? "bg-Highlight" : "bg-Primary"
-        }`}
-      >
-        <p className="text-center title-font leading-[48.96px]">{title}</p>
-      </div>
+    <div
+      className={`z-[50] sticky top-0 flex w-full p-0 min-h-[82px] justify-center items-center ${
+        title === "일기 쓰기" ? "bg-Highlight" : "bg-Primary"
+      }`}
+    >
+      <p className="text-center title-font leading-[48.96px]">{title}</p>
+    </div>
   );
 };
 

--- a/src/components/header/HeaderWithLike.tsx
+++ b/src/components/header/HeaderWithLike.tsx
@@ -3,12 +3,12 @@ import React from 'react';
 
 const HeaderWithLike: React.FC = () => {
   return (
-      <div className="sticky top-0 flex w-full p-0 h-[82px] justify-center items-center bg-Lemon">
-        <p className="text-center font-[400] title-font leading-[48.96px]">일기장</p>
-        <div className="absolute right-4">
-          <LikeIcon status={0} />
-        </div>
+    <div className="z-[50] sticky top-0 flex w-full p-0 h-[82px] justify-center items-center bg-Lemon">
+      <p className="text-center font-[400] title-font leading-[48.96px]">일기장</p>
+      <div className="absolute right-4">
+        <LikeIcon status={0} />
       </div>
+    </div>
   );
 };
 

--- a/src/components/header/HeaderWithLike.tsx
+++ b/src/components/header/HeaderWithLike.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 const HeaderWithLike: React.FC = () => {
   return (
-    <div className="z-[50] sticky top-0 flex w-full p-0 h-[82px] justify-center items-center bg-Lemon">
+    <div className="z-[50] sticky top-0 flex w-full p-0 min-h-[82px] justify-center items-center bg-Lemon">
       <p className="text-center title-font leading-[48.96px]">일기장</p>
       <div className="absolute right-4">
         <LikeIcon status={0} />

--- a/src/components/header/HeaderWithProfile.tsx
+++ b/src/components/header/HeaderWithProfile.tsx
@@ -16,7 +16,7 @@ const HeaderWithProfile: React.FC<HeaderWithProfileProps> = ({ title }) => {
   return (
     <>
       <div
-        className={`z-[50] sticky top-0 flex w-full p-0 h-[82px] justify-center items-center ${
+        className={`z-[50] sticky top-0 flex w-full p-0 min-h-[82px] justify-center items-center min-w-[990px] ${
           title === "띠로리" ? "bg-Primary" : "bg-Lime"
         }`}
       >
@@ -28,7 +28,7 @@ const HeaderWithProfile: React.FC<HeaderWithProfileProps> = ({ title }) => {
         </div>
       </div>
       {isProfileModalOpen && (
-        <div className="absolute right-6 top-0 translate-y-[105px]">
+        <div className="z-[10] fixed right-6 top-0 translate-y-[105px]">
           <ProfileModal nickName="" />
         </div>
       )}

--- a/src/components/header/HeaderWithProfile.tsx
+++ b/src/components/header/HeaderWithProfile.tsx
@@ -1,22 +1,38 @@
 import ProfileIcon from "@components/iconComponents/ProfileIcon";
-import React from "react";
+import ProfileModal from "@components/modals/ProfileModal";
+import React, { useState } from "react";
 
 interface HeaderWithProfileProps {
   title: "띠로리" | "좋아요한 일기들" | "일기 검색하기";
 }
 
 const HeaderWithProfile: React.FC<HeaderWithProfileProps> = ({ title }) => {
+  const [isProfileModalOpen, setIsProfileModalOpen] = useState<boolean>(false);
+
+  const handleProfileIconClick = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    setIsProfileModalOpen(!isProfileModalOpen);
+  };
   return (
+    <>
       <div
-        className={`sticky top-0 flex w-full p-0 h-[82px] justify-center items-center ${
+        className={`z-[50] sticky top-0 flex w-full p-0 h-[82px] justify-center items-center ${
           title === "띠로리" ? "bg-Primary" : "bg-Lime"
         }`}
       >
         <p className="text-center font-[400] title-font leading-[48.96px]">{title}</p>
-        <div className="absolute right-4">
-          <ProfileIcon />
+        <div className="absolute right-6">
+          <button onClick={handleProfileIconClick}>
+            <ProfileIcon />
+          </button>
         </div>
       </div>
+      {isProfileModalOpen && (
+        <div className="absolute right-6 top-0 translate-y-[105px]">
+          <ProfileModal nickName="" />
+        </div>
+      )}
+    </>
   );
 };
 

--- a/src/components/iconComponents/XIcon.tsx
+++ b/src/components/iconComponents/XIcon.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction } from 'react'
+import React from 'react'
 import XIconImage from "@assets/svgs/XIcon.svg";
 
 interface XIconProps {

--- a/src/components/modals/ModalLayout.tsx
+++ b/src/components/modals/ModalLayout.tsx
@@ -1,4 +1,5 @@
 import React, { SetStateAction } from "react";
+import ReactDOM from "react-dom";
 
 interface ModalLayoutProps {
   children: React.ReactNode;
@@ -13,13 +14,13 @@ function ModalLayout({ children, setIsModalOpen }: ModalLayoutProps) {
     }
   };
 
-  return (
+  return ReactDOM.createPortal(
     <div
       className="fixed inset-0 flex items-center justify-center z-50 bg-[rgba(0,0,0,0.11)]"
       onClick={handleBackgroundClick}
     >
       {children}
-    </div>
+    </div>,document.body,
   );
 }
 

--- a/src/components/modals/ProfileModal.tsx
+++ b/src/components/modals/ProfileModal.tsx
@@ -51,7 +51,7 @@ const ProfileModal: React.FC<ProfileModalProps> = ({ nickName }) => {
   };
 
   return (
-    <div className="flex flex-col w-[400px] h-[340px] body-font font-[400] text-center leading-[38.08px] p-[20px] gap-[27px] border border-ButtonDisabledStroke shadow-custom">
+    <div className="flex flex-col w-[400px] h-[340px] body-font font-[400] text-center leading-[38.08px] p-[20px] gap-[27px] border border-ButtonDisabledStroke shadow-custom z-10 bg-white">
       {profileItems.map((item) => (
         <div
           key={item}

--- a/src/index.css
+++ b/src/index.css
@@ -34,6 +34,6 @@ body {
     @apply text-Gray text-huge;
   }
   .calender-item {
-    @apply w-[150px] h-[170px] rounded-[10px];
+    @apply w-full h-[170px] rounded-[10px];
   }
 }

--- a/src/pages/MainPage/components/DateManipulationBar.tsx
+++ b/src/pages/MainPage/components/DateManipulationBar.tsx
@@ -10,7 +10,7 @@ interface Props {
 }
 const DateManipulationBar: React.FC<Props> = ({ date, prevMonthHandler, nextMonthHandler }) => {
   return (
-    <div className="w-[990px] h-[50px] bg-white flex justify-between">
+    <div className="w-full h-[50px] bg-white flex justify-between">
       <LeftArrowIcon onClick={prevMonthHandler} />
       <div className="title-font">{format(date, "yyyy년 M월")}</div>
       <RightArrowIcon onClick={nextMonthHandler} />

--- a/src/pages/MainPage/components/calender/Calender.tsx
+++ b/src/pages/MainPage/components/calender/Calender.tsx
@@ -36,7 +36,7 @@ const renderCalenderItem = (day: Date, currentDate: Date, events: CalenderDataTy
 
 const Calender: React.FC<Props> = ({ currentMonthData, currentDate, calenderData }) => {
   return (
-    <div className="w-[1150px] min-h-[1067px] border-[3px] border-ButtonDisabled rounded-[10px] flex flex-col items-center gap-[54px]">
+    <div className="w-full min-w-[990px] min-h-[1067px] border-[3px] border-ButtonDisabled rounded-[10px] flex flex-col items-center gap-[54px]">
       <div className="flex w-full justify-around mt-[48px]">
         {DAY_LIST.map((day) => (
           <div
@@ -49,7 +49,7 @@ const Calender: React.FC<Props> = ({ currentMonthData, currentDate, calenderData
           </div>
         ))}
       </div>
-      <div className="grid grid-cols-7 gap-x-[12px] gap-y-[11px]">
+      <div className="grid grid-cols-7 w-fit gap-x-[12px] gap-y-[11px]">
         {currentMonthData.map((day) => renderCalenderItem(day, currentDate, calenderData))}
       </div>
     </div>

--- a/src/pages/MainPage/components/calender/CalenderView.tsx
+++ b/src/pages/MainPage/components/calender/CalenderView.tsx
@@ -12,6 +12,8 @@ import {
 } from "date-fns";
 import { useDateControl } from "@hooks/useDateControl";
 import { CalenderDataType } from "src/types/diaryTypes";
+import DiaryList from "@components/diary/DiaryList";
+import { useToggleStore } from "@store/useToggleStore";
 
 const DUMMY_DATA = [
   {
@@ -48,6 +50,7 @@ const CalenderView: React.FC = () => {
   const monthEnd = endOfMonth(currentDate); // 현재 달의 마지막 날짜 (요일 포함)
   const startDate = startOfWeek(monthStart); // 현재 달의 시작 날짜가 포함된 주의 시작 날짜
   const endDate = endOfWeek(monthEnd); // 현재 달의 마지막 날짜가 포함된 주의 끝 날짜
+  const { isCalenderView } = useToggleStore();
 
   const currentMonthData = useMemo(() => {
     const monthArray = [];
@@ -71,13 +74,16 @@ const CalenderView: React.FC = () => {
         prevMonthHandler={prevMonthHandler}
         nextMonthHandler={nextMonthHandler}
       />
-      {calenderData && (
-        <Calender
-          currentMonthData={currentMonthData}
-          currentDate={currentDate}
-          calenderData={calenderData}
-        />
-      )}
+      {calenderData &&
+        (isCalenderView === true ? (
+          <Calender
+            currentMonthData={currentMonthData}
+            currentDate={currentDate}
+            calenderData={calenderData}
+          />
+        ) : (
+          <DiaryList />
+        ))}
     </div>
   );
 };

--- a/src/pages/MainPage/components/calender/CalenderView.tsx
+++ b/src/pages/MainPage/components/calender/CalenderView.tsx
@@ -65,7 +65,7 @@ const CalenderView: React.FC = () => {
   }, [currentDate]);
 
   return (
-    <div className="w-fit flex flex-col items-center gap-[64px]">
+    <div className="w-full min-w-[990px] flex flex-col items-center gap-[64px]">
       <DateManipulationBar
         date={currentDate}
         prevMonthHandler={prevMonthHandler}

--- a/src/pages/MainPage/page/index.tsx
+++ b/src/pages/MainPage/page/index.tsx
@@ -1,7 +1,24 @@
-import React from 'react';
+import ToggleButton from "@components/buttons/ToggleButton";
+import HeaderWithProfile from "@components/header/HeaderWithProfile";
+import SearchIcon from "@components/search/SearchIcon";
+import React from "react";
+import CalenderView from "../components/calender/CalenderView";
 
 const MainPage: React.FC = () => {
-  return <div>MainPage</div>;
+  return (
+    <div className="flex flex-col h-screen w-screen">
+      <HeaderWithProfile title="띠로리" />
+      <div className="flex flex-grow items-center flex-col gap-[48px] px-[130px] py-[53px]">
+        <div className="flex justify-between w-full min-w-[990px]">
+          <ToggleButton leftTitle="캘린더형" rightTitle="목록형" />
+          <button>
+            <SearchIcon />
+          </button>
+        </div>
+        <CalenderView />
+      </div>
+    </div>
+  );
 };
 
 export default MainPage;

--- a/src/pages/MainPage/page/index.tsx
+++ b/src/pages/MainPage/page/index.tsx
@@ -6,7 +6,7 @@ import CalenderView from "../components/calender/CalenderView";
 
 const MainPage: React.FC = () => {
   return (
-    <div className="flex flex-col h-screen w-screen">
+    <div className="flex flex-col h-screen w-full">
       <HeaderWithProfile title="띠로리" />
       <div className="flex flex-grow items-center flex-col gap-[48px] px-[130px] py-[53px]">
         <div className="flex justify-between w-full min-w-[990px]">

--- a/src/store/useToggleStore.ts
+++ b/src/store/useToggleStore.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface ToggleState{
+    isCalenderView: boolean;
+    isTotalView: boolean;
+    setIsCalenderView: (isCalenderView: boolean) => void;
+    setIsTotalView: (isTotalView: boolean) => void;
+}
+
+export const useToggleStore = create<ToggleState>(
+  persist(
+    (set) => ({
+      isCalenderView: true,
+      isTotalView: true,
+      setIsCalenderView: (isCalenderView) =>
+        set({
+          isCalenderView,
+        }),
+      setIsTotalView: (isTotalView) =>
+        set({
+          isTotalView,
+        }),
+    }),
+    { name: "title-storage" },
+  ) as (set: (fn: (state: ToggleState) => ToggleState) => void) => ToggleState,
+);


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #37 

## 📝작업 내용
> - 메인 페이지 캘린더형 및 목록형 퍼블리싱 작업 완료  
> - zustand로 관리하는 toggleButton의 캘린더형인지 목록형인지 여부를 따지는 isCalenderView 전역 상태 변수를 CalenderView에서 불러오는 로직 추가 후 그에 따라 보여주는 컴포넌트 다르게 로직 수정
> - toggleButton 컴포넌트에서 zustand로 title을  전역상태관리하며 그에 따른 toggleButton 컴포넌트 로직 수정 

### 스타일 수정 작업
> - ProfileModal의 배경색을 지정안해줘서 z-index를 지정했음에도 뒤의 검색 아이콘이 보이는 오류를 bg-white로 지정해줌으로써 해결
> - 화면 중앙에 뜨는 모달을 감싸는 ModalLayout 컴포넌트에 ReactDOM.createPortal 로직을 추가함으로써 어느곳에서나 무조건 화면 중앙에 뜰 수 있도록 추가
> - 모든 헤더 컴포넌트들 z-index: 50 속성 추가
> - 캘린더 관련 컴포넌트들에서 width가 고정되어있던 속성을 min-w-[990px]과 w-full을 줌으로써 화면 너비에 따라 변하도록 수정
> - DiaryItem, DiaryList 컴포넌트의 너비가 고정되어 있던걸 화면너비가 변하면 최소 너비만큼만 줄어들고 늘어나거나 줄어들 수 있도록 수정
> - 메인 페이지의 html요소 너비가 실제 화면의 너비보다 작아서 스크롤이 생기던 오류 수정(메인페이지의 너비를 w-screen이 아닌 w-full로 수정)
> - 헤더 컴포넌트들(DefaultHeader, HeaderWithLike, HeaderWithProfile)의 높이가 스토리북에서 보이는 높이와 다르게 짧았던 오류 수정(min-h-[82px]로 수정)


### 스크린샷 (선택)
![제목 없는 동영상 - Clipchamp로 제작](https://github.com/user-attachments/assets/493b7e68-00e2-451b-8ba0-f8d621084ef0)

## 💬리뷰 요구사항(선택)
> - DiaryList 컴포넌트에서 필요한 Props 추가는 api 연동작업 하면서 수정할 예정입니다..