### PR TITLE
Style : 일기 상세 페이지 퍼블리싱

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ function App() {
       <Routes>
         <Route path="/" element={<MainPage />} />
         <Route path="/login" element={<LoginPage />} />
-        <Route path="/writeDiary" element={<WriteDiaryPage />} />
+        <Route path="/write" element={<WriteDiaryPage />} />
         <Route path="/liked" element={<LikedPage />} />
         <Route path="/diary/:diaryId" element={<DiaryPage />} />
         <Route path="/search" element={<SearchPage />} />

--- a/src/components/buttons/BigButton.tsx
+++ b/src/components/buttons/BigButton.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 
 interface BigButtonProps {
-  text: "홈으로 이동하기" | "일기 자랑하기" | "일기 저장하기";
+  title: "홈으로 이동하기" | "일기 자랑하기" | "일기 저장하기";
   color: "gray" | "yellow" | "blue";
   onClick?: () => void;
 }
 
-const BigButton: React.FC<BigButtonProps> = ({ text, color, onClick }) => {
+const BigButton: React.FC<BigButtonProps> = ({ title, color, onClick }) => {
   const buttonClasses = () => {
     switch (color) {
       case "gray":
@@ -24,7 +24,7 @@ const BigButton: React.FC<BigButtonProps> = ({ text, color, onClick }) => {
       className={`w-[429px] h-[82px] flex justify-center items-center rounded-[15px] border ${buttonClasses()} text-regular leading-[38.08px]`}
       onClick={onClick}
     >
-      {text}
+      {title}
     </button>
   );
 };

--- a/src/components/buttons/Button.stories.tsx
+++ b/src/components/buttons/Button.stories.tsx
@@ -10,10 +10,10 @@ function Button() {
     <div className="flex flex-col gap-12">
       <div className="flex flex-col gap-8">
         <h1 className="text-16 bg-white w-fit p-4">BigButton</h1>
-        <BigButton text="일기 자랑하기" color="blue" />
-        <BigButton text="홈으로 이동하기" color="blue" />
-        <BigButton text="일기 저장하기" color="yellow" />
-        <BigButton text="일기 저장하기" color="gray" />
+        <BigButton title="일기 자랑하기" color="blue" />
+        <BigButton title="홈으로 이동하기" color="blue" />
+        <BigButton title="일기 저장하기" color="yellow" />
+        <BigButton title="일기 저장하기" color="gray" />
       </div>
 
       <div className="flex flex-col gap-8">

--- a/src/components/diary/Diary.tsx
+++ b/src/components/diary/Diary.tsx
@@ -1,8 +1,10 @@
 import MoodList from "@components/iconComponents/mood/MoodList";
 import WeatherList from "@components/iconComponents/weather/WeatherList";
-import React, { useState } from "react";
+import React from "react";
 import ImageCreationPanel from "@components/diary/image/ImageCreationPanel";
 import InputSection from "@components/diary/InputSection";
+import useImageStore from "@store/imageStore";
+import useDiaryStore from "@store/diaryStore";
 
 interface Props {
   date: string;
@@ -11,31 +13,34 @@ interface Props {
   isFull: boolean;
 }
 
-const MAXIMUM_WORD = 250;
-const WORD_LIMIT = 150;
-
 const Diary: React.FC<Props> = ({ date, name, count, isFull }) => {
-  const [content, setContent] = useState("");
-  const [selectedMood, setSelectedMood] = useState<string | null>(null);
-  const [selectedWeather, setSelectedWeather] = useState<string | null>(null);
+  const { mood, weather, title, setTitle, content, setContent, limitLength, maxLength } =
+    useDiaryStore();
+  const isValidate = !!(mood && weather && title && content.length >= limitLength);
+
+  const { image } = useImageStore();
+
+  const handleTitleChange = (value: string) => {
+    if (title.length <= 15) setTitle(value);
+  };
 
   const handleInputChange = (value: string) => {
-    if (value.length <= MAXIMUM_WORD) setContent(value);
+    if (value.length <= maxLength) setContent(value);
   };
 
   return (
-    <div className="w-[1150px] h-[1600px] border-[3px] border-Charcoal flex flex-col">
+    <div className="w-[1150px] h-[1600px] border-[3px] border-Charcoal flex flex-col mt-[85px] mb-[50px]">
       <div className="w-full flex justify-center items-center py-[12px] title-font border-b-[3px] border-Charcoal ">
         {date} {name}의 일기
       </div>
       <div className="flex w-full border-b-[3px] border-Charcoal">
         <div className="option-box border-r-[3px] border-Charcoal">
           <div className="title-font">기분 : </div>
-          <MoodList selectedMood={selectedMood} setSelectedMood={setSelectedMood} />
+          <MoodList />
         </div>
         <div className="option-box">
           <div className="title-font">날씨 : </div>
-          <WeatherList selectedWeather={selectedWeather} setSelectedWeather={setSelectedWeather} />
+          <WeatherList />
         </div>
       </div>
       <div className="w-full h-[75px] border-b-[3px] border-Charcoal pl-[70px] flex items-center">
@@ -43,20 +48,22 @@ const Diary: React.FC<Props> = ({ date, name, count, isFull }) => {
         <input
           className="ml-[18px] w-[700px] h-[45px] focus:outline-none title-font placeholder-Gray"
           type="text"
+          value={title}
           placeholder="제목을 입력해주세요."
+          onChange={(e) => handleTitleChange(e.target.value)}
         />
       </div>
       <div className="flex items-center justify-center w-full h-[648px] border-b-[3px] border-Charcoal">
-        <ImageCreationPanel
-          count={count}
-          isFull={isFull}
-          isValidate={content.length > WORD_LIMIT}
-        />
+        {image ? (
+          <img src={image} className="w-full h-full" />
+        ) : (
+          <ImageCreationPanel count={count} isFull={isFull} isValidate={isValidate} images={[]} />
+        )}
       </div>
       <InputSection
         content={content}
-        wordLimit={WORD_LIMIT}
-        maxLength={MAXIMUM_WORD}
+        wordLimit={limitLength}
+        maxLength={maxLength}
         onChange={handleInputChange}
       />
     </div>

--- a/src/components/diary/Diary.tsx
+++ b/src/components/diary/Diary.tsx
@@ -5,20 +5,25 @@ import ImageCreationPanel from "@components/diary/image/ImageCreationPanel";
 import InputSection from "@components/diary/InputSection";
 import useImageStore from "@store/imageStore";
 import useDiaryStore from "@store/diaryStore";
+import { useLocation } from "react-router-dom";
+import DefaultDiaryLogo from "@components/default/DefaultDiaryLogo";
+import DisplaySection from "@components/diary/DisplaySection";
+import { format, parseISO } from "date-fns";
 
 interface Props {
   date: string;
   name: string;
-  count: number;
-  isFull: boolean;
+  count?: number;
+  isFull?: boolean;
 }
 
 const Diary: React.FC<Props> = ({ date, name, count, isFull }) => {
+  const location = useLocation();
   const { mood, weather, title, setTitle, content, setContent, limitLength, maxLength } =
     useDiaryStore();
-  const isValidate = !!(mood && weather && title && content.length >= limitLength);
-
   const { image } = useImageStore();
+  const isValidate = !!(mood && weather && title && content.length >= limitLength);
+  const isDiaryPage = location.pathname.includes("diary");
 
   const handleTitleChange = (value: string) => {
     if (title.length <= 15) setTitle(value);
@@ -31,16 +36,16 @@ const Diary: React.FC<Props> = ({ date, name, count, isFull }) => {
   return (
     <div className="w-[1150px] h-[1600px] border-[3px] border-Charcoal flex flex-col mt-[85px] mb-[50px]">
       <div className="w-full flex justify-center items-center py-[12px] title-font border-b-[3px] border-Charcoal ">
-        {date} {name}의 일기
+        {format(parseISO(date), "yyyy년 MM월 dd일")} {name}의 일기
       </div>
       <div className="flex w-full border-b-[3px] border-Charcoal">
         <div className="option-box border-r-[3px] border-Charcoal">
           <div className="title-font">기분 : </div>
-          <MoodList />
+          <MoodList disabled={isDiaryPage} />
         </div>
         <div className="option-box">
           <div className="title-font">날씨 : </div>
-          <WeatherList />
+          <WeatherList disabled={isDiaryPage} />
         </div>
       </div>
       <div className="w-full h-[75px] border-b-[3px] border-Charcoal pl-[70px] flex items-center">
@@ -51,21 +56,28 @@ const Diary: React.FC<Props> = ({ date, name, count, isFull }) => {
           value={title}
           placeholder="제목을 입력해주세요."
           onChange={(e) => handleTitleChange(e.target.value)}
+          readOnly={isDiaryPage}
         />
       </div>
       <div className="flex items-center justify-center w-full h-[648px] border-b-[3px] border-Charcoal">
         {image ? (
           <img src={image} className="w-full h-full" />
+        ) : isDiaryPage ? (
+          <DefaultDiaryLogo />
         ) : (
-          <ImageCreationPanel count={count} isFull={isFull} isValidate={isValidate} images={[]} />
+          <ImageCreationPanel count={count!} isFull={isFull!} isValidate={isValidate} images={[]} />
         )}
       </div>
-      <InputSection
-        content={content}
-        wordLimit={limitLength}
-        maxLength={maxLength}
-        onChange={handleInputChange}
-      />
+      {isDiaryPage ? (
+        <DisplaySection content={content} />
+      ) : (
+        <InputSection
+          content={content}
+          wordLimit={limitLength}
+          maxLength={maxLength}
+          onChange={handleInputChange}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/diary/DisplaySection.tsx
+++ b/src/components/diary/DisplaySection.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from "react";
+
+interface Props {
+  content: string;
+}
+
+const COLS = 24;
+const ROWS = 15;
+
+const DisplaySection: React.FC<Props> = ({ content }) => {
+  const initializeGrid = () => Array(COLS * ROWS).fill("");
+  const [grid, setGrid] = useState<string[]>(initializeGrid);
+
+  useEffect(() => {
+    const paddedContent = content.padEnd(COLS * ROWS, " ");
+    setGrid(Array.from(paddedContent));
+  }, [content]);
+
+  return (
+    <div
+      className="grid gap-0 w-full flex-grow"
+      style={{
+        gridTemplateRows: `repeat(${ROWS}, 1fr)`,
+        gridTemplateColumns: `repeat(${COLS}, 1fr)`,
+      }}
+    >
+      {grid.map((word) => (
+        <div className="border border-gray-300 flex items-center justify-center text-black text-regular">
+          {word}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default DisplaySection;

--- a/src/components/diary/image/ImageCreationPanel.tsx
+++ b/src/components/diary/image/ImageCreationPanel.tsx
@@ -1,11 +1,16 @@
-import React from "react";
+import React, { useState } from "react";
 import ImagesHistoryButton from "@components/diary/image/ImagesHistoryButton";
 import SmallButton from "@components/buttons/SmallButton";
+import useImageStore from "@store/imageStore";
+import DefaultModal from "@components/modals/DefaultModal";
+import ModalLayout from "@components/modals/ModalLayout";
+import ImageEditModal from "@components/modals/ImageEditModal";
 
 interface Props {
   count: number;
   isFull: boolean;
   isValidate: boolean;
+  images: string[];
 }
 
 const NotificationMessage: React.FC<Pick<Props, "count">> = ({ count }) => {
@@ -21,10 +26,31 @@ const NotificationMessage: React.FC<Pick<Props, "count">> = ({ count }) => {
   }
 };
 
-const ImageCreationPanel: React.FC<Props> = ({ count, isFull, isValidate }) => {
+const ImageCreationPanel: React.FC<Props> = ({ count, isFull, isValidate, images }) => {
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [isHistoryModalOpen, setIsHistoryModalOpen] = useState<boolean>(false);
+  const { setImage } = useImageStore();
+
+  const handleImageHistory = () => {
+    setIsHistoryModalOpen(true);
+  };
+
+  const handleDrawClick = () => {
+    setIsModalOpen(true);
+  };
+
+  const handleYesClick = () => {
+    setImage("생성된 그림"); // api 호출로 대체
+    setIsModalOpen(false);
+  };
+
+  const handleNoClick = () => {
+    setIsModalOpen(false);
+  };
+
   return (
     <div className="flex flex-col gap-[18px] items-center">
-      <ImagesHistoryButton isFull={isFull} />
+      <ImagesHistoryButton isFull={isFull} onClick={handleImageHistory} />
       <NotificationMessage count={count} />
       {count > 0 &&
         (isFull ? (
@@ -33,8 +59,28 @@ const ImageCreationPanel: React.FC<Props> = ({ count, isFull, isValidate }) => {
             그림을 더 생성하고 싶으면 저장 공간을 비워주세요
           </div>
         ) : (
-          <SmallButton title="그림 그려줘!" color={`${isValidate ? "green" : "gray"}`} />
+          <SmallButton
+            title="그림 그려줘!"
+            color={`${isValidate ? "green" : "gray"}`}
+            onClick={handleDrawClick}
+          />
         ))}
+      {isModalOpen && (
+        <ModalLayout setIsModalOpen={setIsModalOpen}>
+          <DefaultModal
+            title="그림을 그리면 오늘 생성 가능 횟수가 소진돼요! 띠로리에게 그림을 그려달라고 할까요?"
+            leftText="넹"
+            rightText="아니용"
+            leftClick={handleYesClick}
+            rightClick={handleNoClick}
+          />
+        </ModalLayout>
+      )}
+      {isHistoryModalOpen && (
+        <ModalLayout setIsModalOpen={setIsHistoryModalOpen}>
+          <ImageEditModal images={images} setIsImageEditModalOpen={setIsHistoryModalOpen} />
+        </ModalLayout>
+      )}
     </div>
   );
 };

--- a/src/components/iconComponents/mood/MoodList.tsx
+++ b/src/components/iconComponents/mood/MoodList.tsx
@@ -1,41 +1,41 @@
-import React, { Dispatch, SetStateAction } from "react";
+import React from "react";
 import SmileIcon from "@components/iconComponents/mood/moodItem/SmileIcon";
 import SadIcon from "@components/iconComponents/mood/moodItem/SadIcon";
 import MediocreIcon from "@components/iconComponents/mood/moodItem/MediocreIcon";
 import AngryIcon from "@components/iconComponents/mood/moodItem/AngryIcon";
 import ExcitedIcon from "@components/iconComponents/mood/moodItem/ExcitedIcon";
 import HappyIcon from "@components/iconComponents/mood/moodItem/HappyIcon";
+import useDiaryStore from "@store/diaryStore";
 
 interface MoodListProps {
-  selectedMood: string | null;
-  setSelectedMood: Dispatch<SetStateAction<string | null>>;
   disabled?: boolean;
 }
 
-const MoodList: React.FC<MoodListProps> = ({ selectedMood, setSelectedMood, disabled }) => {
+const MoodList: React.FC<MoodListProps> = ({ disabled }) => {
+  const { mood, setMood } = useDiaryStore();
   const handleMoodClick = (mood: string) => {
-    setSelectedMood(mood);
+    setMood(mood);
   };
 
   return (
     <div className="flex gap-[20px]">
       <button onClick={() => handleMoodClick("smile")} disabled={disabled}>
-        <SmileIcon isClick={selectedMood === "smile"} />
+        <SmileIcon isClick={mood === "smile"} />
       </button>
       <button onClick={() => handleMoodClick("sad")} disabled={disabled}>
-        <SadIcon isClick={selectedMood === "sad"} />
+        <SadIcon isClick={mood === "sad"} />
       </button>
       <button onClick={() => handleMoodClick("mediocre")} disabled={disabled}>
-        <MediocreIcon isClick={selectedMood === "mediocre"} />
+        <MediocreIcon isClick={mood === "mediocre"} />
       </button>
       <button onClick={() => handleMoodClick("angry")} disabled={disabled}>
-        <AngryIcon isClick={selectedMood === "angry"} />
+        <AngryIcon isClick={mood === "angry"} />
       </button>
       <button onClick={() => handleMoodClick("excited")} disabled={disabled}>
-        <ExcitedIcon isClick={selectedMood === "excited"} />
+        <ExcitedIcon isClick={mood === "excited"} />
       </button>
       <button onClick={() => handleMoodClick("happy")} disabled={disabled}>
-        <HappyIcon isClick={selectedMood === "happy"} />
+        <HappyIcon isClick={mood === "happy"} />
       </button>
     </div>
   );

--- a/src/components/iconComponents/weather/WeatherList.tsx
+++ b/src/components/iconComponents/weather/WeatherList.tsx
@@ -1,45 +1,41 @@
-import React, { Dispatch, SetStateAction } from "react";
+import React from "react";
 import SunnyIcon from "@components/iconComponents/weather/weatherItem/SunnyIcon";
 import RainyIcon from "@components/iconComponents/weather/weatherItem/RainyIcon";
 import SnowyIcon from "@components/iconComponents/weather/weatherItem/SnowyIcon";
 import ThunderStormIcon from "@components/iconComponents/weather/weatherItem/ThunderStormIcon";
 import CloudyIcon from "@components/iconComponents/weather/weatherItem/CloudyIcon";
 import WindyIcon from "@components/iconComponents/weather/weatherItem/WindyIcon";
+import useDiaryStore from "@store/diaryStore";
 
 interface WeatherListProps {
-  selectedWeather: string | null;
-  setSelectedWeather: Dispatch<SetStateAction<string | null>>;
   disabled?: boolean;
 }
 
-const WeatherList: React.FC<WeatherListProps> = ({
-  selectedWeather,
-  setSelectedWeather,
-  disabled,
-}) => {
+const WeatherList: React.FC<WeatherListProps> = ({ disabled }) => {
+  const { weather, setWeather } = useDiaryStore();
   const handleWeatherClick = (weather: string) => {
-    setSelectedWeather(weather);
+    setWeather(weather);
   };
 
   return (
     <div className="flex gap-[20px]">
       <button onClick={() => handleWeatherClick("sunny")} disabled={disabled}>
-        <SunnyIcon isClick={selectedWeather === "sunny"} />
+        <SunnyIcon isClick={weather === "sunny"} />
       </button>
       <button onClick={() => handleWeatherClick("rainy")} disabled={disabled}>
-        <RainyIcon isClick={selectedWeather === "rainy"} />
+        <RainyIcon isClick={weather === "rainy"} />
       </button>
       <button onClick={() => handleWeatherClick("snowy")} disabled={disabled}>
-        <SnowyIcon isClick={selectedWeather === "snowy"} />
+        <SnowyIcon isClick={weather === "snowy"} />
       </button>
       <button onClick={() => handleWeatherClick("thunderstorm")} disabled={disabled}>
-        <ThunderStormIcon isClick={selectedWeather === "thunderstorm"} />
+        <ThunderStormIcon isClick={weather === "thunderstorm"} />
       </button>
       <button onClick={() => handleWeatherClick("cloudy")} disabled={disabled}>
-        <CloudyIcon isClick={selectedWeather === "cloudy"} />
+        <CloudyIcon isClick={weather === "cloudy"} />
       </button>
       <button onClick={() => handleWeatherClick("windy")} disabled={disabled}>
-        <WindyIcon isClick={selectedWeather === "windy"} />
+        <WindyIcon isClick={weather === "windy"} />
       </button>
     </div>
   );

--- a/src/components/modals/ImageEditModal.tsx
+++ b/src/components/modals/ImageEditModal.tsx
@@ -21,14 +21,17 @@ interface ImageEditModalProps {
 const ImageEditModal: React.FC<ImageEditModalProps> = ({ images, setIsImageEditModalOpen }) => {
   const [isEdit, setIsEdit] = useState<boolean>(false);
   const [isDeleteImageModal, setIsDeleteImageModal] = useState<boolean>(false);
+
   const handleCloseModal = () => {
     setIsImageEditModalOpen(false);
   };
+
   const handleImageClick = () => {
     // 해당 일기의 그림 변경 api 연동
 
-    !isEdit && setIsImageEditModalOpen(false);
+    if (!isEdit) setIsImageEditModalOpen(false);
   };
+
   const handleEditClick = () => {
     setIsEdit(!isEdit);
   };

--- a/src/pages/DiaryPage/components/ButtonSection.tsx
+++ b/src/pages/DiaryPage/components/ButtonSection.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from "react";
+import BigButton from "@components/buttons/BigButton";
+import SmallButton from "@components/buttons/SmallButton";
+import ModalLayout from "@components/modals/ModalLayout";
+import DefaultModal from "@components/modals/DefaultModal";
+
+const ButtonSection: React.FC = () => {
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false);
+  const [isShareModalOpen, setIsShareModalOpen] = useState<boolean>(false);
+
+  const handleDeleteClick = () => {
+    // 삭제 api 호출
+    setIsDeleteModalOpen(false);
+  };
+
+  return (
+    <>
+      <div className="flex w-[1150px] justify-between mb-[80px]">
+        <div className="flex gap-[38px]">
+          <SmallButton title="수정하기" color="green" />
+          <SmallButton title="지우기" color="green" onClick={() => setIsDeleteModalOpen(true)} />
+        </div>
+        <BigButton title="일기 자랑하기" color="blue" onClick={() => setIsShareModalOpen(true)} />
+      </div>
+      {isDeleteModalOpen && (
+        <ModalLayout setIsModalOpen={setIsDeleteModalOpen}>
+          <DefaultModal
+            title="앗 이 일기를 지울까요??"
+            leftText="넹"
+            rightText="아니용"
+            leftClick={handleDeleteClick}
+            rightClick={() => setIsDeleteModalOpen(false)}
+          />
+        </ModalLayout>
+      )}
+      {isShareModalOpen && (
+        <ModalLayout setIsModalOpen={setIsShareModalOpen}>
+          <DefaultModal
+            title="짱 멋진 일기를 어떻게 자랑할까요?"
+            leftText="이미지로"
+            rightText="링크로"
+            leftClick={() => console.log("이미지로 공유")}
+            rightClick={() => console.log("링크로 공유")}
+          />
+        </ModalLayout>
+      )}
+    </>
+  );
+};
+
+export default ButtonSection;

--- a/src/pages/DiaryPage/components/DiaryButtonSection.tsx
+++ b/src/pages/DiaryPage/components/DiaryButtonSection.tsx
@@ -4,7 +4,7 @@ import SmallButton from "@components/buttons/SmallButton";
 import ModalLayout from "@components/modals/ModalLayout";
 import DefaultModal from "@components/modals/DefaultModal";
 
-const ButtonSection: React.FC = () => {
+const DiaryButtonSection: React.FC = () => {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false);
   const [isShareModalOpen, setIsShareModalOpen] = useState<boolean>(false);
 
@@ -48,4 +48,4 @@ const ButtonSection: React.FC = () => {
   );
 };
 
-export default ButtonSection;
+export default DiaryButtonSection;

--- a/src/pages/DiaryPage/page/index.tsx
+++ b/src/pages/DiaryPage/page/index.tsx
@@ -4,7 +4,7 @@ import useDiaryStore from "@store/diaryStore";
 import useImageStore from "@store/imageStore";
 import React, { useEffect } from "react";
 import { DiaryDataType } from "src/types/diaryTypes";
-import ButtonSection from "@pages/DiaryPage/components/ButtonSection";
+import DiaryButtonSection from "@pages/DiaryPage/components/DiaryButtonSection";
 
 const DiaryPage: React.FC = () => {
   const { setMood, setWeather, setTitle, setContent } = useDiaryStore();
@@ -41,7 +41,7 @@ const DiaryPage: React.FC = () => {
         count={diaryData.count}
         isFull={diaryData.isFull}
       />
-      <ButtonSection />
+      <DiaryButtonSection />
     </div>
   );
 };

--- a/src/pages/DiaryPage/page/index.tsx
+++ b/src/pages/DiaryPage/page/index.tsx
@@ -1,7 +1,49 @@
-import React from "react";
+import Diary from "@components/diary/Diary";
+import HeaderWithLike from "@components/header/HeaderWithLike";
+import useDiaryStore from "@store/diaryStore";
+import useImageStore from "@store/imageStore";
+import React, { useEffect } from "react";
+import { DiaryDataType } from "src/types/diaryTypes";
+import ButtonSection from "@pages/DiaryPage/components/ButtonSection";
 
 const DiaryPage: React.FC = () => {
-  return <div>DiaryPage</div>;
+  const { setMood, setWeather, setTitle, setContent } = useDiaryStore();
+  const { setImage } = useImageStore();
+  const diaryData: DiaryDataType = {
+    id: 1,
+    date: "2024-08-13",
+    nickname: "팡팡이",
+    mood: "smile",
+    weather: "sunny",
+    title: "신나는 산책을 했따",
+    image: null,
+    story:
+      "아침에 쿨쿨자고 일어나서 밥 먹고 응가하고 엄마랑 놀았따. 그러고 밥 먹고 낮잠을 자고 또 아빠랑 놀았따. 점심을 먹고 소화 시킬겸 언니랑 산책을 나갔다. 여기저기 신기한 냄새들을 잔뜩 맡았따. 완전 신나는 하루였따",
+  };
+
+  useEffect(() => {
+    const diarySetting = () => {
+      setMood(diaryData.mood);
+      setWeather(diaryData.weather);
+      setTitle(diaryData.title);
+      setContent(diaryData.story);
+      setImage(diaryData.image);
+    };
+    diarySetting();
+  }, []);
+
+  return (
+    <div className="flex flex-col items-center">
+      <HeaderWithLike />
+      <Diary
+        date={diaryData.date}
+        name={diaryData.nickname}
+        count={diaryData.count}
+        isFull={diaryData.isFull}
+      />
+      <ButtonSection />
+    </div>
+  );
 };
 
 export default DiaryPage;

--- a/src/pages/WriteDiaryPage/components/WriteDiaryButtonSection.tsx
+++ b/src/pages/WriteDiaryPage/components/WriteDiaryButtonSection.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from "react";
+import DefaultModal from "@components/modals/DefaultModal";
+import ModalLayout from "@components/modals/ModalLayout";
+import BigButton from "@components/buttons/BigButton";
+import SmallButton from "@components/buttons/SmallButton";
+import useDiaryStore from "@store/diaryStore";
+import useImageStore from "@store/imageStore";
+
+const WriteDiaryButtonSection: React.FC = () => {
+  const [isResetModalOpen, setIsResetModalOpen] = useState<boolean>(false);
+  const [isImageModalOpen, setIsImageModalOpen] = useState<boolean>(false);
+  const [isSaveModalOpen, setIsSaveModalOpen] = useState<boolean>(false);
+  const { content, clearContent, limitLength, clearAll } = useDiaryStore();
+  const { image, clearImage } = useImageStore();
+  const isValid = content.length >= limitLength;
+
+  const handleResetClick = () => {
+    clearContent();
+    setIsResetModalOpen(false);
+  };
+
+  const handleImageDeleteClick = () => {
+    clearImage();
+    setIsImageModalOpen(false);
+  };
+
+  const handleSaveClick = () => {
+    console.log("저장됨"); // api 호출로 후에 처리
+    clearImage();
+    clearAll();
+    setIsSaveModalOpen(false);
+  };
+
+  return (
+    <>
+      <div className="flex w-[1150px] justify-between mb-[80px]">
+        <div className="flex gap-[38px]">
+          <SmallButton
+            title="일기 초기화"
+            color="green"
+            onClick={() => setIsResetModalOpen(true)}
+          />
+          {image && (
+            <SmallButton
+              title="그림 지우기"
+              color="green"
+              onClick={() => setIsImageModalOpen(true)}
+            />
+          )}
+        </div>
+        <BigButton
+          title="일기 저장하기"
+          color={`${isValid ? "yellow" : "gray"}`}
+          onClick={() => isValid && setIsSaveModalOpen(true)}
+        />
+      </div>
+      {isResetModalOpen && (
+        <ModalLayout setIsModalOpen={setIsResetModalOpen}>
+          <DefaultModal
+            title="일기를 초기화 할까요?"
+            leftText="넹"
+            rightText="아니용"
+            leftClick={handleResetClick}
+            rightClick={() => setIsResetModalOpen(false)}
+          />
+        </ModalLayout>
+      )}
+      {isImageModalOpen && (
+        <ModalLayout setIsModalOpen={setIsImageModalOpen}>
+          <DefaultModal
+            title="이 그림을 삭제할까요?"
+            leftText="넹"
+            rightText="아니용"
+            leftClick={handleImageDeleteClick}
+            rightClick={() => setIsImageModalOpen(false)}
+          />
+        </ModalLayout>
+      )}
+      {isSaveModalOpen && (
+        <ModalLayout setIsModalOpen={setIsSaveModalOpen}>
+          <DefaultModal
+            title="이대로 일기를 저장할까요?"
+            leftText="넹"
+            rightText="아니용"
+            leftClick={handleSaveClick}
+            rightClick={() => setIsSaveModalOpen(false)}
+          />
+        </ModalLayout>
+      )}
+    </>
+  );
+};
+
+export default WriteDiaryButtonSection;

--- a/src/pages/WriteDiaryPage/page/index.tsx
+++ b/src/pages/WriteDiaryPage/page/index.tsx
@@ -1,96 +1,56 @@
-import BigButton from "@components/buttons/BigButton";
-import SmallButton from "@components/buttons/SmallButton";
 import Diary from "@components/diary/Diary";
 import DefaultHeader from "@components/header/DefaultHeader";
-import DefaultModal from "@components/modals/DefaultModal";
-import ModalLayout from "@components/modals/ModalLayout";
+import React, { useEffect } from "react";
+import WriteDiaryButtonSection from "@pages/WriteDiaryPage/components/WriteDiaryButtonSection";
+import { DiaryDataType } from "src/types/diaryTypes";
 import useDiaryStore from "@store/diaryStore";
 import useImageStore from "@store/imageStore";
-import React, { useState } from "react";
 
 const WriteDiaryPage: React.FC = () => {
-  const [isResetModalOpen, setIsResetModalOpen] = useState<boolean>(false);
-  const [isImageModalOpen, setIsImageModalOpen] = useState<boolean>(false);
-  const [isSaveModalOpen, setIsSaveModalOpen] = useState<boolean>(false);
-  const { content, clearContent, limitLength, clearAll } = useDiaryStore();
-  const { image, clearImage } = useImageStore();
-  const isValid = content.length >= limitLength;
-
-  const handleResetClick = () => {
-    clearContent();
-    setIsResetModalOpen(false);
+  const { setMood, setWeather, setTitle, setContent, clearAll } = useDiaryStore();
+  const { setImage, clearImage } = useImageStore();
+  // 수정 또는 임시저장된 데이터가 있는 경우 api 호출
+  const diaryData: DiaryDataType = {
+    id: 1,
+    date: "2024-08-13",
+    nickname: "팡팡이",
+    count: 2,
+    isFull: false,
+    mood: "smile",
+    weather: "sunny",
+    title: "신나는 산책을 했따",
+    image: "null",
+    story:
+      "아침에 쿨쿨자고 일어나서 밥 먹고 응가하고 엄마랑 놀았따. 그러고 밥 먹고 낮잠을 자고 또 아빠랑 놀았따. 점심을 먹고 소화 시킬겸 언니랑 산책을 나갔다. 여기저기 신기한 냄새들을 잔뜩 맡았따. 완전 신나는 하루였따",
   };
 
-  const handleImageDeleteClick = () => {
-    clearImage();
-    setIsImageModalOpen(false);
-  };
+  useEffect(() => {
+    const diarySetting = () => {
+      setMood(diaryData.mood);
+      setWeather(diaryData.weather);
+      setTitle(diaryData.title);
+      setContent(diaryData.story);
+      setImage(diaryData.image);
+    };
 
-  const handleSaveClick = () => {
-    console.log("저장됨"); // api 호출로 후에 처리
-    clearImage();
-    clearAll();
-    setIsSaveModalOpen(false);
-  };
+    if (diaryData) {
+      diarySetting();
+    } else {
+      clearAll();
+      clearImage();
+    }
+  }, []);
 
   return (
     <div className="flex flex-col items-center">
       <DefaultHeader title="일기 쓰기" />
-      <Diary date="2024년 8월 10일" name="최은진" count={3} isFull={false} />
-      <div className="flex w-[1150px] justify-between mb-[80px]">
-        <div className="flex gap-[38px]">
-          <SmallButton
-            title="일기 초기화"
-            color="green"
-            onClick={() => setIsResetModalOpen(true)}
-          />
-          {image && (
-            <SmallButton
-              title="그림 지우기"
-              color="green"
-              onClick={() => setIsImageModalOpen(true)}
-            />
-          )}
-        </div>
-        <BigButton
-          title="일기 저장하기"
-          color={`${isValid ? "yellow" : "gray"}`}
-          onClick={() => isValid && setIsSaveModalOpen(true)}
-        />
-      </div>
-      {isResetModalOpen && (
-        <ModalLayout setIsModalOpen={setIsResetModalOpen}>
-          <DefaultModal
-            title="일기를 초기화 할까요?"
-            leftText="넹"
-            rightText="아니용"
-            leftClick={handleResetClick}
-            rightClick={() => setIsResetModalOpen(false)}
-          />
-        </ModalLayout>
-      )}
-      {isImageModalOpen && (
-        <ModalLayout setIsModalOpen={setIsImageModalOpen}>
-          <DefaultModal
-            title="이 그림을 삭제할까요?"
-            leftText="넹"
-            rightText="아니용"
-            leftClick={handleImageDeleteClick}
-            rightClick={() => setIsImageModalOpen(false)}
-          />
-        </ModalLayout>
-      )}
-      {isSaveModalOpen && (
-        <ModalLayout setIsModalOpen={setIsSaveModalOpen}>
-          <DefaultModal
-            title="이대로 일기를 저장할까요?"
-            leftText="넹"
-            rightText="아니용"
-            leftClick={handleSaveClick}
-            rightClick={() => setIsSaveModalOpen(false)}
-          />
-        </ModalLayout>
-      )}
+      <Diary
+        date={diaryData.date}
+        name={diaryData.nickname}
+        count={diaryData.count}
+        isFull={diaryData.isFull}
+      />
+      <WriteDiaryButtonSection />
     </div>
   );
 };

--- a/src/pages/WriteDiaryPage/page/index.tsx
+++ b/src/pages/WriteDiaryPage/page/index.tsx
@@ -1,7 +1,98 @@
-import React from "react";
+import BigButton from "@components/buttons/BigButton";
+import SmallButton from "@components/buttons/SmallButton";
+import Diary from "@components/diary/Diary";
+import DefaultHeader from "@components/header/DefaultHeader";
+import DefaultModal from "@components/modals/DefaultModal";
+import ModalLayout from "@components/modals/ModalLayout";
+import useDiaryStore from "@store/diaryStore";
+import useImageStore from "@store/imageStore";
+import React, { useState } from "react";
 
 const WriteDiaryPage: React.FC = () => {
-  return <div>WriteDiaryPage</div>;
+  const [isResetModalOpen, setIsResetModalOpen] = useState<boolean>(false);
+  const [isImageModalOpen, setIsImageModalOpen] = useState<boolean>(false);
+  const [isSaveModalOpen, setIsSaveModalOpen] = useState<boolean>(false);
+  const { content, clearContent, limitLength, clearAll } = useDiaryStore();
+  const { image, clearImage } = useImageStore();
+  const isValid = content.length >= limitLength;
+
+  const handleResetClick = () => {
+    clearContent();
+    setIsResetModalOpen(false);
+  };
+
+  const handleImageDeleteClick = () => {
+    clearImage();
+    setIsImageModalOpen(false);
+  };
+
+  const handleSaveClick = () => {
+    console.log("저장됨"); // api 호출로 후에 처리
+    clearImage();
+    clearAll();
+    setIsSaveModalOpen(false);
+  };
+
+  return (
+    <div className="flex flex-col items-center">
+      <DefaultHeader title="일기 쓰기" />
+      <Diary date="2024년 8월 10일" name="최은진" count={3} isFull={false} />
+      <div className="flex w-[1150px] justify-between mb-[80px]">
+        <div className="flex gap-[38px]">
+          <SmallButton
+            title="일기 초기화"
+            color="green"
+            onClick={() => setIsResetModalOpen(true)}
+          />
+          {image && (
+            <SmallButton
+              title="그림 지우기"
+              color="green"
+              onClick={() => setIsImageModalOpen(true)}
+            />
+          )}
+        </div>
+        <BigButton
+          title="일기 저장하기"
+          color={`${isValid ? "yellow" : "gray"}`}
+          onClick={() => isValid && setIsSaveModalOpen(true)}
+        />
+      </div>
+      {isResetModalOpen && (
+        <ModalLayout setIsModalOpen={setIsResetModalOpen}>
+          <DefaultModal
+            title="일기를 초기화 할까요?"
+            leftText="넹"
+            rightText="아니용"
+            leftClick={handleResetClick}
+            rightClick={() => setIsResetModalOpen(false)}
+          />
+        </ModalLayout>
+      )}
+      {isImageModalOpen && (
+        <ModalLayout setIsModalOpen={setIsImageModalOpen}>
+          <DefaultModal
+            title="이 그림을 삭제할까요?"
+            leftText="넹"
+            rightText="아니용"
+            leftClick={handleImageDeleteClick}
+            rightClick={() => setIsImageModalOpen(false)}
+          />
+        </ModalLayout>
+      )}
+      {isSaveModalOpen && (
+        <ModalLayout setIsModalOpen={setIsSaveModalOpen}>
+          <DefaultModal
+            title="이대로 일기를 저장할까요?"
+            leftText="넹"
+            rightText="아니용"
+            leftClick={handleSaveClick}
+            rightClick={() => setIsSaveModalOpen(false)}
+          />
+        </ModalLayout>
+      )}
+    </div>
+  );
 };
 
 export default WriteDiaryPage;

--- a/src/store/diaryStore.ts
+++ b/src/store/diaryStore.ts
@@ -32,7 +32,7 @@ const useDiaryStore = create<DiaryState>((set) => ({
       title: "",
       content: "",
     }),
-  maxLength: 250,
+  maxLength: 240,
   limitLength: 150,
 }));
 

--- a/src/store/diaryStore.ts
+++ b/src/store/diaryStore.ts
@@ -1,0 +1,39 @@
+import { create } from "zustand";
+
+interface DiaryState {
+  mood: string | null;
+  setMood: (mood: string | null) => void;
+  weather: string | null;
+  setWeather: (weather: string | null) => void;
+  title: string;
+  setTitle: (title: string) => void;
+  content: string;
+  setContent: (content: string) => void;
+  clearContent: () => void;
+  clearAll: () => void;
+  maxLength: number;
+  limitLength: number;
+}
+
+const useDiaryStore = create<DiaryState>((set) => ({
+  mood: null,
+  setMood: (mood: string | null) => set({ mood }),
+  weather: null,
+  setWeather: (weather: string | null) => set({ weather }),
+  title: "",
+  setTitle: (title: string) => set({ title }),
+  content: "",
+  setContent: (content: string) => set({ content }),
+  clearContent: () => set({ content: "" }),
+  clearAll: () =>
+    set({
+      mood: null,
+      weather: null,
+      title: "",
+      content: "",
+    }),
+  maxLength: 250,
+  limitLength: 150,
+}));
+
+export default useDiaryStore;

--- a/src/store/imageStore.ts
+++ b/src/store/imageStore.ts
@@ -2,13 +2,13 @@ import { create } from "zustand";
 
 interface ImageState {
   image: string | null;
-  setImage: (image: string) => void;
+  setImage: (image: string | null) => void;
   clearImage: () => void;
 }
 
 const useImageStore = create<ImageState>((set) => ({
   image: null,
-  setImage: (image: string) => set({ image }),
+  setImage: (image: string | null) => set({ image }),
   clearImage: () => set({ image: null }),
 }));
 

--- a/src/store/imageStore.ts
+++ b/src/store/imageStore.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+interface ImageState {
+  image: string | null;
+  setImage: (image: string) => void;
+  clearImage: () => void;
+}
+
+const useImageStore = create<ImageState>((set) => ({
+  image: null,
+  setImage: (image: string) => set({ image }),
+  clearImage: () => set({ image: null }),
+}));
+
+export default useImageStore;

--- a/src/types/diaryTypes.ts
+++ b/src/types/diaryTypes.ts
@@ -4,3 +4,16 @@ export type CalenderDataType = {
   image: string;
   bookmark: number;
 };
+
+export type DiaryDataType = {
+  id: number;
+  date: string;
+  nickname: string;
+  count?: number;
+  isFull?: boolean;
+  mood: string;
+  weather: string;
+  title: string;
+  image: string | null;
+  story: string;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

close #49

## 📝작업 내용

### 작업 사항
- 일기 상세 페이지 퍼블리싱
- DiaryPage, WriteDiaryPage 내 버튼 컴포넌트 분리 : DiaryButtonSection , WriteDiaryButtonSection
- DiaryDataType 정의 => 일기 조회 api 응답데이터

### 수정 사항
- Diary 컴포넌트 내에서 "일기 상세 페이지" 인지 "일기 수정/작성 페이지"인지 구분하기 위해 endpoint 이름을 수정 했습니다. 
: /writeDiary => /write

### 스크린샷 (선택)

https://github.com/user-attachments/assets/d0c6cc31-6180-4a78-96e2-8faaa88d0d68


## 💬리뷰 요구사항(선택)
- 일기 조회 시 응답 받는 데이터 타입에 count, isFull 필드가 백엔드 api 명세서 상에는 없어서 추가해달라고 요청을 드려야할 것 같습니다.
