### PR TITLE
Hotfix: 좋아요페이지 오류 수정

### DIFF
--- a/src/api/liked/useLikeStatus.ts
+++ b/src/api/liked/useLikeStatus.ts
@@ -29,7 +29,9 @@ export const useLikeStatus = (id: number, isListPage?: boolean) => {
   const queryClient = useQueryClient();
   const { currentDate } = useDateControl();
   const { isTotalView } = useToggleStore();
-  const queryKey = ["likedDiaries", isTotalView, format(currentDate, "yyyyMM")];
+  const queryKey = isTotalView
+    ? ["likedDiaries", isTotalView]
+    : ["likedDiaries", isTotalView, format(currentDate, "yyyyMM")];
 
   return useMutation<
     LikeStatusResponse,
@@ -62,7 +64,15 @@ export const useLikeStatus = (id: number, isListPage?: boolean) => {
       }
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey });
+      queryClient.invalidateQueries({
+        queryKey: ["likedDiaries", true],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["likedDiaries", false, format(currentDate, "yyyyMM")],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [`diary${id}`],
+      });
     },
   });
 };

--- a/src/api/liked/useLikedDiaries.ts
+++ b/src/api/liked/useLikedDiaries.ts
@@ -20,8 +20,13 @@ const fetchLikedDiaries = async (
 };
 
 export const useLikedDiaries = (isTotalView: boolean, currentDate: string) => {
+  const queryKey = isTotalView
+    ? ["likedDiaries", isTotalView]
+    : ["likedDiaries", isTotalView, currentDate];
+
   return useQuery<DiaryListType[]>({
-    queryKey: ["likedDiaries", isTotalView, currentDate],
+    queryKey,
     queryFn: () => fetchLikedDiaries(isTotalView, currentDate),
+    staleTime: 300000, // 5분
   });
 };

--- a/src/components/buttons/ToggleButton.tsx
+++ b/src/components/buttons/ToggleButton.tsx
@@ -39,8 +39,6 @@ const ToggleButton: React.FC<ToggleButtonProps> = ({ leftTitle, rightTitle }) =>
       }
       setIsLeftActive(true);
     }
-
-    console.log(activeButtonTitle, leftTitle);
   };
 
   return (

--- a/src/components/buttons/ToggleButton.tsx
+++ b/src/components/buttons/ToggleButton.tsx
@@ -39,6 +39,8 @@ const ToggleButton: React.FC<ToggleButtonProps> = ({ leftTitle, rightTitle }) =>
       }
       setIsLeftActive(true);
     }
+
+    console.log(activeButtonTitle, leftTitle);
   };
 
   return (

--- a/src/components/diary/list/DiaryItem.tsx
+++ b/src/components/diary/list/DiaryItem.tsx
@@ -2,12 +2,17 @@ import LikeIcon from "@components/iconComponents/LikeIcon";
 import DefaultDiaryLogo from "@components/default/DefaultDiaryLogo";
 import { format } from "date-fns";
 import { DiaryListType } from "src/types/diaryTypes";
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 const DiaryItem = ({ id, image, title, date, bookmark }: DiaryListType) => {
+  const navigate = useNavigate();
+  const handleClick = () => {
+    navigate(`/diary/${id}`);
+  };
+
   return (
-    <Link
-      to={`/diary/${id}`}
+    <button
+      onClick={handleClick}
       className="min-w-[1012.53px] h-[275px] bg-white flex items-center justify-between border-b-[3px] border-buttonDisabled"
     >
       <div className="flex items-center gap-[46px]">
@@ -22,7 +27,7 @@ const DiaryItem = ({ id, image, title, date, bookmark }: DiaryListType) => {
         </div>
       </div>
       <LikeIcon bookmark={bookmark} id={id} isListPage />
-    </Link>
+    </button>
   );
 };
 

--- a/src/components/iconComponents/LikeIcon.tsx
+++ b/src/components/iconComponents/LikeIcon.tsx
@@ -9,7 +9,8 @@ interface LikeIconProps {
 const LikeIcon = ({ bookmark = false, id, isListPage }: LikeIconProps) => {
   const { data: likeStatus = { bookmark }, mutate: toggleLike } = useLikeStatus(id, isListPage);
 
-  const handleClick = () => {
+  const handleClick = (event: React.MouseEvent<SVGSVGElement>) => {
+    event.stopPropagation();
     toggleLike();
   };
 

--- a/src/hooks/useDateControl.ts
+++ b/src/hooks/useDateControl.ts
@@ -1,16 +1,17 @@
+import { useDateStore } from "@store/useDateStore";
 import { addMonths, subMonths } from "date-fns";
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 
 export const useDateControl = () => {
-  const [currentDate, setCurrentDate] = useState(new Date());
+  const { currentDate, setCurrentDate } = useDateStore();
 
   const prevMonthHandler = useCallback(() => {
     setCurrentDate(subMonths(currentDate, 1));
-  }, [currentDate]);
+  }, [currentDate, setCurrentDate]);
 
   const nextMonthHandler = useCallback(() => {
     setCurrentDate(addMonths(currentDate, 1));
-  }, [currentDate]);
+  }, [currentDate, setCurrentDate]);
 
   return { currentDate, setCurrentDate, prevMonthHandler, nextMonthHandler };
 };

--- a/src/pages/LikedPage/page/index.tsx
+++ b/src/pages/LikedPage/page/index.tsx
@@ -16,8 +16,6 @@ const LikedPage = () => {
     format(currentDate, "yyyyMM"),
   );
 
-  if (isPending) return <div>Loading...</div>;
-
   const DiarySection = () => {
     if (likedDiaries) {
       if (likedDiaries.length === 0) {
@@ -39,16 +37,20 @@ const LikedPage = () => {
         <div className="flex justify-start w-full min-w-[990px]">
           <ToggleButton leftTitle="전체보기" rightTitle="날짜별" />
         </div>
-        <div className="w-full flex-grow flex flex-col items-center gap-[64px]">
-          {!isTotalView && (
-            <DateManipulationBar
-              date={currentDate}
-              prevMonthHandler={prevMonthHandler}
-              nextMonthHandler={nextMonthHandler}
-            />
-          )}
-          <DiarySection />
-        </div>
+        {isPending ? (
+          <div>Loading...</div>
+        ) : (
+          <div className="w-full flex-grow flex flex-col items-center gap-[64px]">
+            {!isTotalView && (
+              <DateManipulationBar
+                date={currentDate}
+                prevMonthHandler={prevMonthHandler}
+                nextMonthHandler={nextMonthHandler}
+              />
+            )}
+            <DiarySection />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/store/useDateStore.ts
+++ b/src/store/useDateStore.ts
@@ -1,0 +1,12 @@
+import { create } from "zustand";
+
+interface DateState {
+  currentDate: Date;
+  setCurrentDate: (currentDate: Date) => void;
+}
+
+export const useDateStore = create<DateState>((set) => ({
+  currentDate: new Date(),
+  setCurrentDate: (currentDate: Date) => set({ currentDate }),
+  clearCurrentDate: () => set({ currentDate: new Date() }),
+}));

--- a/src/store/useDateStore.ts
+++ b/src/store/useDateStore.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 interface DateState {
   currentDate: Date;
   setCurrentDate: (currentDate: Date) => void;
+  clearCurrentDate: () => void;
 }
 
 export const useDateStore = create<DateState>((set) => ({


### PR DESCRIPTION
## #️⃣연관된 이슈

#80 

## 📝작업 내용

### < 수정 내용>
1. 일기 item에서 좋아요 버튼 클릭 시 해당 일기 페이지로 라우팅 되는 오류 발생 => Link 태그 대신 button으로 바꾸고 이벤트 버블링을 막아서 해결
2.  ToggleButton 전체보기 , 날짜별 클릭 시 불필요한 api request 최적화 : staleTime을 5분으로 늘리고 좋아요 status요청에 변화가 있는 경우 쿼리키들을 invalidate 해줘서 상태 업데이트 
3. 좋아요한 페이지 내 로딩 컴포넌트 위치 수정
