### PR TITLE
Feat: 검색페이지 api 연결

### DIFF
--- a/src/api/diary/useSearchDiary.ts
+++ b/src/api/diary/useSearchDiary.ts
@@ -1,0 +1,24 @@
+import { apiRoutes } from "@api/apiRoutes";
+import api from "@api/fetcher";
+import { useQuery } from "@tanstack/react-query";
+import { DiaryListType } from "src/types/diaryTypes";
+
+const searchDiary = async (keyword: string) => {
+  try {
+    const { data }: { data: DiaryListType[] } = await api.get({
+      endpoint: `${apiRoutes.searchDiary}?keyword=${keyword}`,
+    });
+    return data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
+export const useSearchDiary = (keyword: string) => {
+  return useQuery({
+    queryKey: ["searchDiary"],
+    queryFn: () => searchDiary(keyword),
+    enabled: false,
+  });
+};

--- a/src/components/diary/list/DiaryItem.tsx
+++ b/src/components/diary/list/DiaryItem.tsx
@@ -2,9 +2,11 @@ import LikeIcon from "@components/iconComponents/LikeIcon";
 import DefaultDiaryLogo from "@components/default/DefaultDiaryLogo";
 import { format } from "date-fns";
 import { BaseDiaryType } from "src/types/diaryTypes";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 const DiaryItem = ({ id, image, title, date, bookmark }: BaseDiaryType) => {
+  const location = useLocation();
+  const isLikedPage = location.pathname === "/liked";
   const navigate = useNavigate();
   const handleClick = () => {
     navigate(`/diary/${id}`);
@@ -26,7 +28,7 @@ const DiaryItem = ({ id, image, title, date, bookmark }: BaseDiaryType) => {
           <div className="smallCaption-font">{format(date, "yyyy년 M월 d일")}</div>
         </div>
       </div>
-      <LikeIcon bookmark={bookmark} id={id} isListPage />
+      <LikeIcon bookmark={bookmark} id={id} isLikedPage={isLikedPage} />
     </button>
   );
 };

--- a/src/components/diary/list/DiaryList.tsx
+++ b/src/components/diary/list/DiaryList.tsx
@@ -1,5 +1,5 @@
 import DiaryItem from "@components/diary/list/DiaryItem";
-import { BaseDiaryType} from "src/types/diaryTypes";
+import { BaseDiaryType } from "src/types/diaryTypes";
 
 interface Props {
   diaries: BaseDiaryType[];
@@ -7,7 +7,7 @@ interface Props {
 
 const DiaryList = ({ diaries }: Props) => {
   return (
-    <div className="flex flex-col w-full">
+    <div className="flex flex-col w-fit">
       {diaries.map(({ id, title, image, date, bookmark }) => (
         <DiaryItem key={id} id={id} title={title} image={image} date={date} bookmark={bookmark} />
       ))}

--- a/src/components/iconComponents/LikeIcon.tsx
+++ b/src/components/iconComponents/LikeIcon.tsx
@@ -3,11 +3,11 @@ import { useLikeStatus } from "@api/liked/useLikeStatus";
 interface LikeIconProps {
   bookmark: boolean;
   id: number;
-  isListPage?: boolean;
+  isLikedPage?: boolean;
 }
 
-const LikeIcon = ({ bookmark = false, id, isListPage }: LikeIconProps) => {
-  const { data: likeStatus = { bookmark }, mutate: toggleLike } = useLikeStatus(id, isListPage);
+const LikeIcon = ({ bookmark = false, id, isLikedPage }: LikeIconProps) => {
+  const { data: likeStatus = { bookmark }, mutate: toggleLike } = useLikeStatus(id, isLikedPage);
 
   const handleClick = (event: React.MouseEvent<SVGSVGElement>) => {
     event.stopPropagation();

--- a/src/pages/LoginPage/loginHandler/oauthHandler.tsx
+++ b/src/pages/LoginPage/loginHandler/oauthHandler.tsx
@@ -11,15 +11,13 @@ const OAuthRedirectHandler = () => {
   useEffect(() => {
     if (isSuccess && data) {
       localStorage.setItem("access_token", data.access_token);
+      const redirectedFrom = localStorage.getItem("redirectedFrom") || "/";
+      navigate(redirectedFrom, { replace: true });
+      localStorage.removeItem("redirectedFrom");
     }
-  }, [isSuccess, data]);
+  }, [isSuccess, navigate, data]);
 
   if (isPending) return <div>로그인 중</div>;
-  if (isSuccess) {
-    const redirectedFrom = localStorage.getItem("redirectedFrom") || "/";
-    navigate(redirectedFrom, { replace: true });
-    setTimeout(() => localStorage.removeItem("redirectedFrom"), 0);
-  }
   if (isError) return <div>에러발생</div>;
 };
 

--- a/src/pages/SearchPage/components/SearchDiaryView.tsx
+++ b/src/pages/SearchPage/components/SearchDiaryView.tsx
@@ -1,0 +1,31 @@
+import DiaryList from "@components/diary/list/DiaryList";
+import EmptyState from "@components/empty/EmptyState";
+import { DiaryListType } from "src/types/diaryTypes";
+
+interface Props {
+  value: string;
+  data: DiaryListType[] | undefined;
+}
+
+const SearchDiaryView = ({ value, data }: Props) => {
+  if (!value || !data)
+    return (
+      <div className="flex flex-grow justify-center items-center">
+        <EmptyState message="검색어를 입력해주세요!" />
+      </div>
+    );
+
+  if (data) {
+    return data.length === 0 ? (
+      <div className="flex flex-grow justify-center items-center">
+        <EmptyState message={`${value}(으)로 검색된 결과가 없어요!`} />
+      </div>
+    ) : (
+      <div className="w-full flex justify-center items-center mt-[60px]">
+        <DiaryList diaries={data} />
+      </div>
+    );
+  }
+};
+
+export default SearchDiaryView;

--- a/src/pages/SearchPage/page/index.tsx
+++ b/src/pages/SearchPage/page/index.tsx
@@ -1,44 +1,24 @@
-import DiaryList from "@components/diary/list/DiaryList";
-import EmptyState from "@components/empty/EmptyState";
+import { useSearchDiary } from "@api/diary/useSearchDiary";
 import HeaderWithProfile from "@components/header/HeaderWithProfile";
 import SearchBar from "@components/search/SearchBar";
 import React, { useState } from "react";
+import SearchDiaryView from "@pages/SearchPage/components/SearchDiaryView";
+import { useQueryClient } from "@tanstack/react-query";
 
-const results = [
-  {
-    id: 1,
-    date: "2024-08-13",
-    title: "신나는 게임을 했따",
-    image: "",
-    bookmark: true,
-  },
-  {
-    id: 3,
-    date: "2024-08-20",
-    title: "학교 가기 싫다",
-    image: "",
-    bookmark: false,
-  },
-];
-
-const SearchPage: React.FC = () => {
+const SearchPage = () => {
   const [value, setValue] = useState<string>("");
-  const [isSearchClicked, setIsSearchClicked] = useState<boolean>(false);
+  const { data, refetch, isLoading } = useSearchDiary(value);
+  const queryClient = useQueryClient();
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValue(e.target.value);
-    if (value === "") {
-      results.length = 0;
-    }
-    if (isSearchClicked) setIsSearchClicked(false);
+    queryClient.removeQueries({ queryKey: ["searchDiary"] });
   };
 
   const handleSearchClick = () => {
-    if (!value) {
-      return;
+    if (value) {
+      refetch();
     }
-    results.length = 2;
-    setIsSearchClicked(true);
   };
 
   return (
@@ -51,20 +31,7 @@ const SearchPage: React.FC = () => {
           handleClick={handleSearchClick}
         />
       </div>
-
-      {!value || results.length === 0 ? (
-        <div className="flex flex-grow justify-center items-center">
-          <EmptyState message="검색된 결과가 없어요!" />
-        </div>
-      ) : (
-        results.length > 0 && (
-          <div className="w-full flex justify-center items-center mt-[60px]">
-            <div>
-              <DiaryList diaries={[]} />
-            </div>
-          </div>
-        )
-      )}
+      {isLoading ? <div>...Loading</div> : <SearchDiaryView value={value} data={data} />}
     </div>
   );
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

#86

## 📝작업 내용

### <구현 내용>
1. 검색 api 연동
2. 검색어 미입력시 검색어를 입력해달라는 컴포넌트 추가

### < 수정 사항 >
1. oauthHandler에서 로컬스토리지에서 데이터 가져오는 로직과 navigate 로직이 동시에 실행되서 경고 발생 => 수정
2. LikeIcon 버튼 좋아요 페이지일 때 만 onMutation 실행가능하도록

### 스크린샷 (선택)

https://github.com/user-attachments/assets/d8f1a6b1-7d99-4cda-ad79-ef0dcc9aff35

