### PR TITLE
Fix: 메인페이지 캘린더 데이터 받아오는 로직 수정

### DIFF
--- a/src/api/calender/useCalender.ts
+++ b/src/api/calender/useCalender.ts
@@ -9,21 +9,21 @@ type IGetMainDiariesType = {
   data: BaseDiaryType[]
 };
 
-const getMainDiaries = async (type: string, date: string) => {
+const getMainDiaries = async (type: string, startDate: string, endDate: string) => {
   const data = await api.get<IGetMainDiariesType>({
-    endpoint: `${apiRoutes.mainDiary}?type=${type}&date=${date}`,
+    endpoint: `${apiRoutes.mainDiary}?type=${type}&start=${startDate}&end=${endDate}`,
   });
   return data;
 };
 
-export const useGetMainDiaries = (type: boolean, date: string) => {
+export const useGetMainDiaries = (type: boolean, startDate: string, endDate: string) => {
   return useQuery({
-    queryKey: ["MAIN_DIARIES", type, date],
+    queryKey: ["MAIN_DIARIES", type, startDate, endDate],
     queryFn: () => {
       if (type) {
-        return getMainDiaries("calendar", date);
+        return getMainDiaries("calendar", startDate, endDate);
       } else {
-        return getMainDiaries("list", date);
+        return getMainDiaries("list", startDate, endDate);
       }
     },
   });

--- a/src/pages/MainPage/components/calender/CalenderView.tsx
+++ b/src/pages/MainPage/components/calender/CalenderView.tsx
@@ -1,22 +1,19 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import DateManipulationBar from "@pages/MainPage/components/DateManipulationBar";
 import Calender from "@pages/MainPage/components/calender/Calender";
 import {
   addDays,
-  addMonths,
   differenceInCalendarDays,
   endOfMonth,
   endOfWeek,
   startOfMonth,
   startOfWeek,
-  subMonths,
 } from "date-fns";
 import { useDateControl } from "@hooks/useDateControl";
 import DiaryList from "@components/diary/list/DiaryList";
 import { useToggleStore } from "@store/useToggleStore";
 import { format } from "date-fns";
 import EmptyState from "@components/empty/EmptyState";
-import { BaseDiaryType } from "src/types/diaryTypes";
 import { useGetMainDiaries } from "@api/calender/useCalender";
 
 const CalenderView: React.FC = () => {
@@ -26,43 +23,13 @@ const CalenderView: React.FC = () => {
   const startDate = startOfWeek(monthStart); // 현재 달의 시작 날짜가 포함된 주의 시작 날짜
   const endDate = endOfWeek(monthEnd); // 현재 달의 마지막 날짜가 포함된 주의 끝 날짜
   const { isCalenderView } = useToggleStore();
-  const [currentDateParam, setCurrentDateParam] = useState<string>(format(currentDate, "yyyyMM"));
-  const [previousMonthParam, setPreviousMonthParam] = useState<string>(
-    format(subMonths(currentDate, 1), "yyyyMM"),
-  );
-  const [nextMonthParam, setNextMonthParam] = useState<string>(
-    format(addMonths(currentDate, 1), "yyyyMM"),
-  );
 
   // 해당달 캘린더 data
-  const { data: getCurrentMainCalender } = useGetMainDiaries(isCalenderView, currentDateParam);
-
-  // 다음달 캘린더 data
-  const { data: getNextMainCalender } = useGetMainDiaries(isCalenderView, nextMonthParam);
-
-  // 이전달 캘린더 data
-  const { data: getPreviousMainCalender } = useGetMainDiaries(isCalenderView, previousMonthParam);
-
-  const [getTotalCalenderData, setGetTotalCalenderData] = useState<BaseDiaryType[]>();
-
-  useEffect(() => {
-    if (getCurrentMainCalender && getNextMainCalender && getPreviousMainCalender) {
-      setGetTotalCalenderData([
-        ...getCurrentMainCalender.data,
-        ...getNextMainCalender.data,
-        ...getPreviousMainCalender.data,
-      ]);
-    }
-    
-  }, [getCurrentMainCalender, getNextMainCalender, getPreviousMainCalender, currentDateParam]);
-
-  const currentMonth = currentDate.getMonth() + 1;
-
-  useEffect(() => {
-    setCurrentDateParam(format(currentDate, "yyyyMM"));
-    setNextMonthParam(format(addMonths(currentDate, 1), "yyyyMM"));
-    setPreviousMonthParam(format(subMonths(currentDate, 1), "yyyyMM"));
-  }, [currentMonth]);
+  const { data: getCurrentMainCalender } = useGetMainDiaries(
+    isCalenderView,
+    format(startDate, "yyyyMMdd"),
+    format(endDate, "yyyyMMdd"),
+  );
 
   const currentMonthData = useMemo(() => {
     const monthArray = [];
@@ -81,12 +48,12 @@ const CalenderView: React.FC = () => {
         prevMonthHandler={prevMonthHandler}
         nextMonthHandler={nextMonthHandler}
       />
-      {getTotalCalenderData && getCurrentMainCalender && 
+      {getCurrentMainCalender &&
         (isCalenderView === true ? (
           <Calender
             currentMonthData={currentMonthData}
             currentDate={currentDate}
-            calenderData={getTotalCalenderData}
+            calenderData={getCurrentMainCalender.data}
           />
         ) : getCurrentMainCalender.data.length === 0 ? (
           <div className={"h-full w-full flex flex-grow justify-center items-center"}>


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #92 

## 📝수정 내용
> 1. 메인 페이지 캘린더 다이어리 백엔드로부터 받아오는 로직 수정
> 원래 로직 : 이전달, 해당달, 다음달 총 3달의 일기를 가져옴으로써 한달에 대해 3번의 api 호출을 실행함 - 비효율
> 바뀐 로직 : 백엔드에 해당달 달력의 startDate, endDate를 endpoint에 추가해 보냄으로써 단 한번의 api 호출 - 효율

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
