### PR TITLE
Chore: 로컬서버 https로 windows, mac OS 환경에서 적용할 수 있도록 하는 설정 파일 추가 및 package.json에 명령어 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+<div>
+  <p> 
+    - 로컬서버 http -> https로 적용
+ </p>
+ <p>
+    - init-https.sh 파일이 실행되어야 localhost-key.pem, localhost.pem 키 파일이 생성됨
+ </p>
+  <p>
+    - clone or pull 받고 npm install -> npm run init-https 실행한 이후 루트 경로에 init-https.sh파일이랑 .pem 파일 2개 정상적으로 설치 됐는지 확인하고 npm run secure 실행 -> https 적용
+  </p>
+</div>
+
 ## 📖 프로젝트 소개
 > AI를 기반으로한 일기 서비스 : 일기내용을 토대로 AI가 그림일기 그려주는 서비스
 <br/>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     - init-https.sh 파일이 실행되어야 localhost-key.pem, localhost.pem 키 파일이 생성됨
  </p>
   <p>
-    - clone or pull 받고 npm install -> npm run init-https 실행한 이후 루트 경로에 init-https.sh파일이랑 .pem 파일 2개 정상적으로 설치 됐는지 확인하고 npm run secure 실행 -> https 적용
+    - clone or pull 받고 pnpm install -> pnpm run init-https 실행한 이후 루트 경로에 init-https.sh파일이랑 .pem 파일 2개 정상적으로 설치 됐는지 확인하고 pnpm run dev 실행 -> https 적용
   </p>
 </div>
 

--- a/init-https.sh
+++ b/init-https.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# 운영체제 감지
+OS=$(uname)
+
+if [ "$OS" == "Darwin" ]; then
+    # MacOS인 경우
+    MKCERT_INSTALLED=$(which mkcert)
+
+    if [ -z "$MKCERT_INSTALLED" ]; then
+        echo "mkcert가 설치되어 있지 않습니다. brew로 mkcert를 설치합니다."
+        brew install mkcert
+    fi
+elif [ "$OS" == "MINGW64_NT" ] || [ "$OS" == "MINGW32_NT" ] || [ "$OS" == "CYGWIN_NT" ]; then
+    # Windows인 경우
+    MKCERT_INSTALLED=$(where mkcert)
+
+    if [ -z "$MKCERT_INSTALLED" ]; then
+        echo "mkcert가 설치되어 있지 않습니다. choco로 mkcert를 설치합니다."
+        choco install mkcert -y
+    fi
+else
+    echo "지원되지 않는 운영체제입니다."
+    exit 1
+fi
+
+# mkcert 설정 및 localhost 인증서 생성
+mkcert -install
+mkcert localhost
+
+# mkcert 설치 자동화
+# 1. mkcert 설치 여부를 확인하고 설치 안되어 있으면 brew로 mkcert를 설치(MacOS 기준 작성)
+# 2. mkcert -install 실행
+# 3. mkvert localhost 실행

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build-storybook": "storybook build",
     "chromatic": "npx chromatic --project-token=chpt_331321e81a5d63c",
     "prepare": "husky install",
-    "ts": "tsc -b"
+    "ts": "tsc -b",
+    "init-https": "cross-env-shell \"sh init-https.sh || init-https.sh\""
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -46,6 +47,7 @@
     "@vitejs/plugin-react": "^4.3.1",
     "autoprefixer": "^10.4.20",
     "chromatic": "^11.7.1",
+    "cross-env-shell": "^7.0.3",
     "eslint": "8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       chromatic:
         specifier: ^11.7.1
         version: 11.7.1
+      cross-env-shell:
+        specifier: ^7.0.3
+        version: 7.0.3
       eslint:
         specifier: 8.57.0
         version: 8.57.0
@@ -1899,6 +1902,10 @@ packages:
 
   core-js-compat@3.38.1:
     resolution: {integrity: sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==}
+
+  cross-env-shell@7.0.3:
+    resolution: {integrity: sha512-ZEtnHInQRRzuAbmMpUqu/mk1jaZun14WdcmnpzZZ6Bpi1BLTPkbKioQ6+wkFssf+m/DpdttDpsCX6g8zU9W40A==}
+    hasBin: true
 
   cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
@@ -5810,6 +5817,8 @@ snapshots:
   core-js-compat@3.38.1:
     dependencies:
       browserslist: 4.23.3
+
+  cross-env-shell@7.0.3: {}
 
   cross-spawn@7.0.3:
     dependencies:


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> - 로컬서버 https로 windows, mac OS 환경에서 적용할 수 있도록 하는 설정 파일 추가 및 package.json에 명령어 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> - pull 받고 pnpm install -> pnpm run init-https 실행한 이후 루트 경로에 init-https.sh파일이랑 .pem 파일 2개 정상적으로 설치 됐는지 확인하고 pnpm run dev 실행 -> https 적용
