### PR TITLE
HotFix: 메인페이지 목록형 다이어리 api 호출 로직 수정

### DIFF
--- a/src/api/calender/useCalender.ts
+++ b/src/api/calender/useCalender.ts
@@ -1,29 +1,45 @@
 import { apiRoutes } from "@api/apiRoutes";
 import api from "@api/fetcher";
 import { useQuery } from "@tanstack/react-query";
-import { BaseDiaryType} from "src/types/diaryTypes";
+import { BaseDiaryType } from "src/types/diaryTypes";
 
 type IGetMainDiariesType = {
   status: number;
   message: string;
-  data: BaseDiaryType[]
+  data: BaseDiaryType[];
 };
 
-const getMainDiaries = async (type: string, startDate: string, endDate: string) => {
+const getMainDiaries = async (
+  type: string,
+  startDate?: string,
+  endDate?: string,
+  currentDate?: string,
+) => {
+  const endpoint =
+    type === "calendar"
+      ? `${apiRoutes.mainDiary}?type=${type}&start=${startDate}&end=${endDate}`
+      : `${apiRoutes.mainDiary}?type=${type}&date=${currentDate}`;
+  console.log(currentDate)
+  console.log(endpoint);
   const data = await api.get<IGetMainDiariesType>({
-    endpoint: `${apiRoutes.mainDiary}?type=${type}&start=${startDate}&end=${endDate}`,
+    endpoint,
   });
   return data;
 };
 
-export const useGetMainDiaries = (type: boolean, startDate: string, endDate: string) => {
+export const useGetMainDiaries = (
+  type: boolean,
+  startDate: string,
+  endDate: string,
+  currentDate: string,
+) => {
   return useQuery({
-    queryKey: ["MAIN_DIARIES", type, startDate, endDate],
+    queryKey: ["MAIN_DIARIES", type, startDate, endDate, currentDate],
     queryFn: () => {
       if (type) {
         return getMainDiaries("calendar", startDate, endDate);
       } else {
-        return getMainDiaries("list", startDate, endDate);
+        return getMainDiaries("list", undefined, undefined, currentDate);
       }
     },
   });

--- a/src/api/calender/useCalender.ts
+++ b/src/api/calender/useCalender.ts
@@ -19,8 +19,6 @@ const getMainDiaries = async (
     type === "calendar"
       ? `${apiRoutes.mainDiary}?type=${type}&start=${startDate}&end=${endDate}`
       : `${apiRoutes.mainDiary}?type=${type}&date=${currentDate}`;
-  console.log(currentDate)
-  console.log(endpoint);
   const data = await api.get<IGetMainDiariesType>({
     endpoint,
   });

--- a/src/pages/MainPage/components/calender/CalenderView.tsx
+++ b/src/pages/MainPage/components/calender/CalenderView.tsx
@@ -23,12 +23,13 @@ const CalenderView: React.FC = () => {
   const startDate = startOfWeek(monthStart); // 현재 달의 시작 날짜가 포함된 주의 시작 날짜
   const endDate = endOfWeek(monthEnd); // 현재 달의 마지막 날짜가 포함된 주의 끝 날짜
   const { isCalenderView } = useToggleStore();
-
+  
   // 해당달 캘린더 data
   const { data: getCurrentMainCalender } = useGetMainDiaries(
     isCalenderView,
     format(startDate, "yyyyMMdd"),
     format(endDate, "yyyyMMdd"),
+    format(currentDate, "yyyyMM"),
   );
 
   const currentMonthData = useMemo(() => {


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #99 

## 📝수정 내용

> 메인페이지 목록형 다이어리 api 호출 로직 수정
> - type=list 인 경우 : currentDate만 "yyyyMM" 형식으로 endpoint 파라미터에 추가해서 api 요청
> - type=calendar 인 경우 : startDate, endDate를 "yyyyMMdd" 형식으로 endpoint 파라미터에 추가해서 api 요청

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
